### PR TITLE
Expose the fping period configurable parameter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage.xml
 dist/
 site/
 venv/
+.idea/

--- a/vaping/plugins/fping.py
+++ b/vaping/plugins/fping.py
@@ -19,12 +19,14 @@ class FPingBase(vaping.plugins.TimedProbe):
         `command` command to run
         `interval` time between pings
         `count` number of pings to send
+        `period` time in milliseconds that fping waits between successive packets to an individual target
     """
 
     default_config = {
         'command': 'fping',
         'interval': '1m',
         'count': 5,
+        'period': 20
     }
 
     def __init__(self, config, ctx):
@@ -35,6 +37,7 @@ class FPingBase(vaping.plugins.TimedProbe):
             raise RuntimeError("fping command not found")
 
         self.count = int(self.pluginmgr_config.get('count', 0))
+        self.period = int(self.pluginmgr_config.get('period', 0))
 
     def hosts_args(self):
         """
@@ -104,7 +107,7 @@ class FPingBase(vaping.plugins.TimedProbe):
             self.pluginmgr_config['command'],
             '-u',
             '-C%d' % self.count,
-            '-p20',
+            '-p%d' % self.period,
             '-e'
         ]
         args.extend(self.hosts_args())


### PR DESCRIPTION
This PR makes the fping "period" parameter a configurable item rather than being hardcoded to a value of 20.

The issue with the value 20 is that some network devices interpret ICMP packets in such quick succession as a flood and then drop them, thus making the remote system appear as if it is down.

fping with a period value of 20 in my network environment 
```
$ fping -u -C10 -p20 -e 8.8.8.8 4.2.2.1 208.67.222.222
8.8.8.8        : - - - - - - - - - -
4.2.2.1        : - - - - - - - - - -
208.67.222.222 : - - - - - - - - - -
```

fping with a period value of 200 in my network environment 
```
$ fping -u -C10 -p200 -e 8.8.8.8 4.2.2.1 208.67.222.222
8.8.8.8        : 55.86 55.79 56.24 55.68 56.27 55.74 55.43 55.64 55.58 55.15
4.2.2.1        : 164.26 165.31 164.84 163.92 163.81 164.45 164.67 163.94 163.72 163.59
208.67.222.222 : 57.68 57.59 58.42 57.55 57.18 57.89 57.03 57.13 56.90 56.71
```
