### PR TITLE
Fix mtr on python3

### DIFF
--- a/vaping/plugins/fping_mtr.py
+++ b/vaping/plugins/fping_mtr.py
@@ -33,7 +33,7 @@ class FPingMTR(vaping.plugins.fping.FPingBase):
             logging.debug(line)
             host = line.split()[1]
             if host != "*":
-                return str(host)
+                return host.decode('ascii')
 
         except Exception as e:
             logging.error("failed to get data {}".format(e))


### PR DESCRIPTION
```py
Python 2.7.15rc1 (default, Nov 12 2018, 14:31:15) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> b'ala'.decode('ascii')
u'ala'
>>> str(b'ala')
'ala'
>>> 
```
but
```py
Python 3.6.7 (default, Oct 22 2018, 11:32:17) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> b'ala'.decode('ascii')
'ala'
>>> str(b'ala')
"b'ala'"
>>> 
```
so a small fix is needed in order to make mtr feature work on python3