### PR TITLE
Bug: Fix issue 62, vaping crashes when a IP is completely unreachable.

### DIFF
--- a/vaping/plugins/__init__.py
+++ b/vaping/plugins/__init__.py
@@ -438,5 +438,5 @@ class TimeSeriesDB(EmitBase):
 
                 # update database
                 self.log.debug("storing time:%d, %s:%.5f in %s" % (
-                    message.get("ts"), self.field, row.get(self.field), filename))
-                self.update(filename, message.get("ts"), row.get(self.field))
+                    message.get("ts","0.0"), self.field, row.get(self.field.0.0), filename))
+                self.update(filename, message.get("ts","0.0"), row.get(self.field,0.0))


### PR DESCRIPTION
Bug: Fix issue 62, vaping crashes when a IP is completely unreachable.
When there are no statistics, the get operation used to crash. Added 0 as the default value.