### PR TITLE
Need g++ in order to build gevent in the docker image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # image that builds vaping and deps
 FROM base as builder
 
-RUN apk --update --no-cache add gcc make file libc-dev libffi-dev py-gevent $dep_packages
+RUN apk --update --no-cache add gcc g++ make file libc-dev libffi-dev py-gevent $dep_packages
 
 # create venv
 RUN python3 -m venv "$VIRTUAL_ENV"


### PR DESCRIPTION
Another dependency for the docker build.

Without g++ gevent fails to build
```
Step 13/26 : RUN pip install .
 ---> Running in 594440a3d073
Processing /src/vaping
Requirement already satisfied: click>=5.1 in /venv/lib/python3.7/site-packages (from vaping==1.3.0.1) (7.1.2)
Collecting greenlet==0.4.16
  Downloading greenlet-0.4.16.tar.gz (60 kB)
Collecting gevent==1.5.0
  Downloading gevent-1.5.0.tar.gz (5.3 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /venv/bin/python3 /venv/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-x5clgvch/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools >= 40.8.0' wheel 'Cython >= 0.29.14' 'cffi >= 1.12.3 ; platform_python_implementation == '"'"'CPython'"'"'' 'greenlet>=0.4.14 ; platform_python_implementation == '"'"'CPython'"'"''
       cwd: None
  Complete output (105 lines):
  Collecting setuptools>=40.8.0
    Using cached setuptools-54.1.3-py3-none-any.whl (785 kB)
  Collecting wheel
    Using cached wheel-0.36.2-py2.py3-none-any.whl (35 kB)
  Collecting Cython>=0.29.14
    Using cached Cython-0.29.22-py2.py3-none-any.whl (980 kB)
  Collecting cffi>=1.12.3
    Downloading cffi-1.14.5.tar.gz (475 kB)
  Collecting greenlet>=0.4.14
    Downloading greenlet-1.0.0.tar.gz (84 kB)
  Collecting pycparser
    Downloading pycparser-2.20-py2.py3-none-any.whl (112 kB)
  Using legacy 'setup.py install' for cffi, since package 'wheel' is not installed.
  Using legacy 'setup.py install' for greenlet, since package 'wheel' is not installed.
  Installing collected packages: pycparser, wheel, setuptools, greenlet, Cython, cffi
      Running setup.py install for greenlet: started
      Running setup.py install for greenlet: finished with status 'error'
      ERROR: Command errored out with exit status 1:
       command: /venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-33aja_ci/greenlet_16b2416a4d2f4ecb90256f51ff51064d/setup.py'"'"'; __file__='"'"'/tmp/pip-install-33aja_ci/greenlet_16b2416a4d2f4ecb90256f51ff51064d/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8_lt35z7/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-x5clgvch/overlay --compile --install-headers /tmp/pip-build-env-x5clgvch/overlay/include/site/python3.7/greenlet
           cwd: /tmp/pip-install-33aja_ci/greenlet_16b2416a4d2f4ecb90256f51ff51064d/
      Complete output (82 lines):
      running install
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-3.7
      creating build/lib.linux-x86_64-3.7/greenlet
      copying src/greenlet/__init__.py -> build/lib.linux-x86_64-3.7/greenlet
      creating build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_stack_saved.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_gc.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_throw.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_greenlet.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_cpp.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_extension_interface.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_weakref.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_contextvars.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_generator_nested.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_generator.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_leaks.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_version.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/test_tracing.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/__init__.py -> build/lib.linux-x86_64-3.7/greenlet/tests
      running egg_info
      writing src/greenlet.egg-info/PKG-INFO
      writing dependency_links to src/greenlet.egg-info/dependency_links.txt
      writing requirements to src/greenlet.egg-info/requires.txt
      writing top-level names to src/greenlet.egg-info/top_level.txt
      reading manifest file 'src/greenlet.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      no previously-included directories found matching 'docs/_build'
      warning: no files found matching '*.py' under directory 'appveyor'
      warning: no previously-included files matching '*.pyc' found anywhere in distribution
      warning: no previously-included files matching '*.pyd' found anywhere in distribution
      warning: no previously-included files matching '*.so' found anywhere in distribution
      warning: no previously-included files matching '.coverage' found anywhere in distribution
      writing manifest file 'src/greenlet.egg-info/SOURCES.txt'
      copying src/greenlet/greenlet.c -> build/lib.linux-x86_64-3.7/greenlet
      copying src/greenlet/greenlet.h -> build/lib.linux-x86_64-3.7/greenlet
      copying src/greenlet/slp_platformselect.h -> build/lib.linux-x86_64-3.7/greenlet
      creating build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/setup_switch_x64_masm.cmd -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_aarch64_gcc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_alpha_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_amd64_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_arm32_gcc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_arm32_ios.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_csky_gcc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_m68k_gcc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_mips_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_ppc64_aix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_ppc64_linux.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_ppc_aix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_ppc_linux.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_ppc_macosx.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_ppc_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_riscv_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_s390_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_sparc_sun_gcc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_x32_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_x64_masm.asm -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_x64_masm.obj -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_x64_msvc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_x86_msvc.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/platform/switch_x86_unix.h -> build/lib.linux-x86_64-3.7/greenlet/platform
      copying src/greenlet/tests/_test_extension.c -> build/lib.linux-x86_64-3.7/greenlet/tests
      copying src/greenlet/tests/_test_extension_cpp.cpp -> build/lib.linux-x86_64-3.7/greenlet/tests
      running build_ext
      building 'greenlet._greenlet' extension
      creating build/temp.linux-x86_64-3.7
      creating build/temp.linux-x86_64-3.7/src
      creating build/temp.linux-x86_64-3.7/src/greenlet
      gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/venv/include -I/usr/local/include/python3.7m -c src/greenlet/greenlet.c -o build/temp.linux-x86_64-3.7/src/greenlet/greenlet.o
      gcc -shared -Wl,--strip-all build/temp.linux-x86_64-3.7/src/greenlet/greenlet.o -L/usr/local/lib -lpython3.7m -o build/lib.linux-x86_64-3.7/greenlet/_greenlet.cpython-37m-x86_64-linux-gnu.so
      building 'greenlet.tests._test_extension' extension
      creating build/temp.linux-x86_64-3.7/src/greenlet/tests
      gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -Isrc/greenlet/ -I/venv/include -I/usr/local/include/python3.7m -c src/greenlet/tests/_test_extension.c -o build/temp.linux-x86_64-3.7/src/greenlet/tests/_test_extension.o
      gcc -shared -Wl,--strip-all build/temp.linux-x86_64-3.7/src/greenlet/tests/_test_extension.o -L/usr/local/lib -lpython3.7m -o build/lib.linux-x86_64-3.7/greenlet/tests/_test_extension.cpython-37m-x86_64-linux-gnu.so
      building 'greenlet.tests._test_extension_cpp' extension
      gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -Isrc/greenlet/ -I/venv/include -I/usr/local/include/python3.7m -c src/greenlet/tests/_test_extension_cpp.cpp -o build/temp.linux-x86_64-3.7/src/greenlet/tests/_test_extension_cpp.o
      gcc: fatal error: cannot execute 'cc1plus': execvp: No such file or directory
      compilation terminated.
      error: command 'gcc' failed with exit status 1
      ----------------------------------------
  ERROR: Command errored out with exit status 1: /venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-33aja_ci/greenlet_16b2416a4d2f4ecb90256f51ff51064d/setup.py'"'"'; __file__='"'"'/tmp/pip-install-33aja_ci/greenlet_16b2416a4d2f4ecb90256f51ff51064d/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8_lt35z7/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-x5clgvch/overlay --compile --install-headers /tmp/pip-build-env-x5clgvch/overlay/include/site/python3.7/greenlet Check the logs for full command output.
  ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/5a/79/2c63d385d017b5dd7d70983a463dfd25befae70c824fedb857df6e72eff2/gevent-1.5.0.tar.gz#sha256=b2814258e3b3fb32786bb73af271ad31f51e1ac01f33b37426b66cb8491b4c29 (from https://pypi.org/simple/gevent/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*). Command errored out with exit status 1: /venv/bin/python3 /venv/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-x5clgvch/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools >= 40.8.0' wheel 'Cython >= 0.29.14' 'cffi >= 1.12.3 ; platform_python_implementation == '"'"'CPython'"'"'' 'greenlet>=0.4.14 ; platform_python_implementation == '"'"'CPython'"'"'' Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement gevent==1.5.0 (from vaping)
ERROR: No matching distribution found for gevent==1.5.0
The command '/bin/sh -c pip install .' returned a non-zero code: 1
```

The error `gcc: fatal error: cannot execute 'cc1plus': execvp: No such file or directory` led me to g++

With g++ the build completes (here's gevent)

```
Step 13/26 : RUN pip install .
 ---> Running in 76ae5b654487
Processing /src/vaping
Requirement already satisfied: click>=5.1 in /venv/lib/python3.7/site-packages (from vaping==1.3.0.1) (7.1.2)
Collecting greenlet==0.4.16
  Downloading greenlet-0.4.16.tar.gz (60 kB)
Collecting gevent==1.5.0
  Downloading gevent-1.5.0.tar.gz (5.3 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
```

docker build command run (for both)
`sudo docker build -t vaping:$(cat Ctl/VERSION) --build-arg=vaping_uid=1002 .`

Thank you for your work on this project and for making it public.