### PR TITLE
zmq fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 
 ## Unreleased
+### Fixed
+- zmq.asyncio has no attribute `PUB` (#128)
+- zmq plugin configuration collision between bind and connect (#126)
 
 
 ## 1.4.2

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,8 @@
 Unreleased:
   added: []
-  fixed: []
+  fixed:
+  - 'zmq.asyncio has no attribute `PUB` (#128)'
+  - 'zmq plugin configuration collision between bind and connect (#126)'
   changed: []
   deprecated: []
   removed: []

--- a/src/vaping/plugins/zeromq.py
+++ b/src/vaping/plugins/zeromq.py
@@ -48,6 +48,7 @@ class ZeroMQ(vaping.plugins.EmitBase):
                 self.log.critical(msg)
                 raise ValueError(msg)
         elif not self.config.get("connect"):
+            msg = "missing bind or connect"
             self.log.critical(msg)
             raise ValueError(msg)
 


### PR DESCRIPTION
fixes #126: zermoq plugin config validation wants both bind and connect to be set
fixes #128: module 'zmq.asyncio' has no attribute 'PUB'