### PR TITLE
Ignore any None data rows

### DIFF
--- a/src/vaping/plugins/__init__.py
+++ b/src/vaping/plugins/__init__.py
@@ -576,6 +576,10 @@ class TimeSeriesDB(EmitBase):
         if isinstance(message.get("data"), list):
             for row in message.get("data"):
 
+                if row is None:
+                    self.log.debug("Ignoring empty row from %s/%s" % (message.get("source"), message.get("type")))
+                    continue
+
                 # format filename from data
                 filename = self.format_filename(message, row)
 


### PR DESCRIPTION
I'm running the normal `fping` plugin to a bunch of targets.
One of these targets would every now and then become unreachable causing Vaping to crash.

Sadly I don't have the output from `fping` causing the issue, but this patch fixes the problem for me.

This also seems to be related to https://github.com/20c/vaping/issues/134