### PR TITLE
run alpine3.19 to avoid upgrading fping to 5.2 and breaking output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG vaping_extras=all
 
 ARG poetry_pin=">=1,<=2"
 
-FROM python:3.11-alpine as base
+FROM python:3.11-alpine3.19 as base
 
 ARG runtime_packages
 ARG virtual_env=/venv


### PR DESCRIPTION
fixes #191 